### PR TITLE
[fix] Add TLS directory if TLS is enabled

### DIFF
--- a/tasks/tls.yml
+++ b/tasks/tls.yml
@@ -1,6 +1,15 @@
 ---
 # File: tasks/tls.yml - TLS tasks for Vault
 
+- name: Create tls directory
+  file:
+    dest: "{{ item }}"
+    state: directory
+    owner: "{{ vault_user }}"
+    group: "{{ vault_group}}"
+  with_items:
+    - "{{ vault_tls_config_path }}"
+
 - name: Vault SSL Certificate and Key
   copy:
     src:    "{{ item.src }}"


### PR DESCRIPTION
When TLS is enabled, the directory for the TLS cert is not created by default. This adds a task to `tls.yml` to create the directory that the TLS certs are written to.